### PR TITLE
AnimatorParameter - Adds support for Override Controllers

### DIFF
--- a/Reflection/Editor/AnimatorParameterDrawer.cs
+++ b/Reflection/Editor/AnimatorParameterDrawer.cs
@@ -155,7 +155,30 @@ namespace Ludiq.Reflection.Editor
 			var options = new List<DropdownOption<AnimatorParameter>>();
 
 			List<string> names = targets
-				.Select(animator => ((AnimatorController)animator.runtimeAnimatorController))
+				.Select(animator => {
+
+					AnimatorController controller = null;
+
+					// Support for AnimatorOverrideController
+					try {
+						controller = (AnimatorController)animator.runtimeAnimatorController;
+
+					} catch(System.InvalidCastException) {
+						// If can't cast as AnimatorController, probably an AnimatorOverrideController
+						try {
+							AnimatorOverrideController overrideController;
+							overrideController = (AnimatorOverrideController)animator.runtimeAnimatorController;
+
+							controller = (AnimatorController)overrideController.runtimeAnimatorController;
+
+						} catch(System.InvalidCastException) {
+							// Neither worked, so skip it
+							controller = null;
+						}
+					}
+
+					return controller;
+				})
 				.Where(animatorController => animatorController != null)
 				.Select(animatorController => animatorController.parameters)
 				.Select(parameters => parameters.Select(parameter => parameter.name))


### PR DESCRIPTION
I found that the `AnimatorParameter` didn't work if the target's animator had an `AnimatorOverrideController`. It in fact throws an `InvalidCastException` in the console if you drag such an animator in to the target field.

This change basically checks if it is possible to cast the runtime controller as an `AnimatorController`, if not, it attempts to cast to an `AnimatorOverrideController`, otherwise just lets it be null, so it will be filtered by the `Where` clause.